### PR TITLE
CCM-11723 send template control events from prod to test

### DIFF
--- a/infrastructure/terraform/components/events/.tool-versions
+++ b/infrastructure/terraform/components/events/.tool-versions
@@ -1,1 +1,1 @@
-terraform 1.10.1
+terraform 1.12.0

--- a/infrastructure/terraform/components/events/README.md
+++ b/infrastructure/terraform/components/events/README.md
@@ -6,7 +6,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.6 |
 ## Inputs
 
@@ -17,7 +17,7 @@
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | A map of default tags to apply to all taggable resources within the component | `map(string)` | `{}` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the tfscaffold environment | `string` | n/a | yes |
 | <a name="input_event_publisher_account_ids"></a> [event\_publisher\_account\_ids](#input\_event\_publisher\_account\_ids) | An object representing account id's of event publishers | `list(any)` | `[]` | no |
-| <a name="input_event_target_arns"></a> [event\_target\_arns](#input\_event\_target\_arns) | A map of event target ARNs keyed by name | <pre>object({<br/>    sms_nudge             = string<br/>    notify_core_sns_topic = optional(string, null)<br/>  })</pre> | n/a | yes |
+| <a name="input_event_target_arns"></a> [event\_target\_arns](#input\_event\_target\_arns) | A map of event target ARNs keyed by name | <pre>object({<br/>    sms_nudge                               = string<br/>    notify_core_sns_topic                   = optional(string, null)<br/>  })</pre> | n/a | yes |
 | <a name="input_force_lambda_code_deploy"></a> [force\_lambda\_code\_deploy](#input\_force\_lambda\_code\_deploy) | If the lambda package in s3 has the same commit id tag as the terraform build branch, the lambda will not update automatically. Set to True if making changes to Lambda code from on the same commit for example during development | `bool` | `false` | no |
 | <a name="input_group"></a> [group](#input\_group) | The group variables are being inherited from (often synonmous with account short-name) | `string` | n/a | yes |
 | <a name="input_kms_deletion_window"></a> [kms\_deletion\_window](#input\_kms\_deletion\_window) | When a kms key is deleted, how long should it wait in the pending deletion state? | `string` | `"30"` | no |
@@ -27,6 +27,8 @@
 | <a name="input_parent_acct_environment"></a> [parent\_acct\_environment](#input\_parent\_acct\_environment) | Name of the environment responsible for the acct resources used, affects things like DNS zone. Useful for named dev environments | `string` | `"main"` | no |
 | <a name="input_project"></a> [project](#input\_project) | The name of the tfscaffold project | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The AWS Region | `string` | n/a | yes |
+| <a name="input_template_control_cross_account_source"></a> [template\_control\_cross\_account\_source](#input\_template\_control\_cross\_account\_source) | Object containing environment and Account ID of the Control Plane Event Bus to allow Template Events FROM | <pre>object({<br/>    environment = optional(string, null)<br/>    account_id  = optional(string, null)<br/>  })</pre> | `null` | no |
+| <a name="input_template_control_cross_account_target"></a> [template\_control\_cross\_account\_target](#input\_template\_control\_cross\_account\_target) | Object containing environment and Account ID of the Control Plane Event Bus to send Template Events TO | <pre>object({<br/>    environment = optional(string, null)<br/>    account_id  = optional(string, null)<br/>  })</pre> | `null` | no |
 ## Modules
 
 | Name | Source | Version |

--- a/infrastructure/terraform/components/events/cloudwatch_event_bus_policy_control_plane.tf
+++ b/infrastructure/terraform/components/events/cloudwatch_event_bus_policy_control_plane.tf
@@ -17,14 +17,22 @@ data "aws_iam_policy_document" "control_plane_ingest" {
 
     principals {
       type        = "AWS"
-      identifiers = distinct(formatlist("arn:aws:iam::%s:root", var.event_publisher_account_ids))
+      identifiers = distinct(concat(
+        formatlist("arn:aws:iam::%s:root", var.event_publisher_account_ids),
+        var.template_control_cross_account_source != null ? ["arn:aws:iam::${var.template_control_cross_account_source.account_id}:root"] : []
+      ))
     }
     condition {
       test     = "ArnLike"
       variable = "aws:PrincipalArn"
       values = distinct(flatten([
         formatlist("arn:aws:iam::%s:role/comms-*-api-event-publisher", var.event_publisher_account_ids),
-        formatlist("arn:aws:iam::%s:role/nhs-notify-*-eventpub", var.event_publisher_account_ids)
+        formatlist("arn:aws:iam::%s:role/nhs-notify-*-eventpub", var.event_publisher_account_ids),
+        (
+          var.template_control_cross_account_source != null
+        ) ? [
+          "arn:aws:iam::${var.template_control_cross_account_source.account_id}:role/nhs-${var.template_control_cross_account_source.environment}-events-template-control-cross-account"
+        ] : []
       ]))
     }
   }

--- a/infrastructure/terraform/components/events/cloudwatch_event_rule_template_control_cross_account.tf
+++ b/infrastructure/terraform/components/events/cloudwatch_event_rule_template_control_cross_account.tf
@@ -1,0 +1,76 @@
+resource "aws_cloudwatch_event_rule" "template_control_cross_account" {
+  count = ( var.template_control_cross_account_target != null ) ? 1 : 0
+
+  name           = "${local.csi}-template-control-cross-account"
+  description    = "Template Control events to Cross Account Eventbus"
+  event_bus_name = aws_cloudwatch_event_bus.control_plane.name
+
+  event_pattern = jsonencode({
+    "detail" : {
+      "type" : [
+        { "wildcard": "uk.nhs.notify.template-management.TemplateCompleted.*" },
+        { "wildcard": "uk.nhs.notify.template-management.TemplateDrafted.*" },
+        { "wildcard": "uk.nhs.notify.template-management.TemplateDeleted.*" }
+      ]
+      "source" : [
+        "//notify.nhs.uk/app/nhs-notify-template-management-${local.group_suffix}/${var.environment}"
+      ]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "template_control_cross_account" {
+  count = ( var.template_control_cross_account_target != null ) ? 1 : 0
+
+  rule           = aws_cloudwatch_event_rule.template_control_cross_account[0].name
+  arn            = "arn:aws:events:eu-west-2:${var.template_control_cross_account_target.account_id}:event-bus/nhs-${var.template_control_cross_account_target.environment}-events-control-plane"
+  target_id      = "template-control-cross-account"
+  event_bus_name = aws_cloudwatch_event_bus.control_plane.name
+  role_arn       = aws_iam_role.template_control_cross_account[0].arn
+  dead_letter_config {
+    arn = module.template_control_cross_account_dlq[0].sqs_queue_arn
+  }
+}
+
+data "aws_iam_policy_document" "template_control_cross_account" {
+  count = ( var.template_control_cross_account_target != null ) ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "template_control_cross_account" {
+  count = ( var.template_control_cross_account_target != null ) ? 1 : 0
+
+  name = "${local.csi}-template-control-cross-account"
+
+  assume_role_policy = data.aws_iam_policy_document.template_control_cross_account[0].json
+}
+
+resource "aws_iam_policy" "template_control_cross_account" {
+  count = ( var.template_control_cross_account_target != null ) ? 1 : 0
+
+  name = "${local.csi}-template-control-cross-account"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = "events:PutEvents",
+      Resource = "arn:aws:events:eu-west-2:${var.template_control_cross_account_target.account_id}:event-bus/nhs-${var.template_control_cross_account_target.environment}-events-control-plane"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "template_control_cross_account" {
+  count = ( var.template_control_cross_account_target != null ) ? 1 : 0
+
+  role       = aws_iam_role.template_control_cross_account[0].name
+  policy_arn = aws_iam_policy.template_control_cross_account[0].arn
+}

--- a/infrastructure/terraform/components/events/locals.tf
+++ b/infrastructure/terraform/components/events/locals.tf
@@ -1,4 +1,4 @@
 locals {
   aws_lambda_functions_dir_path = "../../../../lambdas"
+  group_suffix                  = element(split("-", var.group),-1)
 }
-

--- a/infrastructure/terraform/components/events/module_kms.tf
+++ b/infrastructure/terraform/components/events/module_kms.tf
@@ -57,14 +57,22 @@ data "aws_iam_policy_document" "kms" {
       actions = ["kms:GenerateDataKey"]
       principals {
         type        = "AWS"
-        identifiers = distinct(formatlist("arn:aws:iam::%s:root", var.event_publisher_account_ids))
+        identifiers = distinct(concat(
+          formatlist("arn:aws:iam::%s:root", var.event_publisher_account_ids),
+          var.template_control_cross_account_source != null ? ["arn:aws:iam::${var.template_control_cross_account_source.account_id}:root"] : []
+        ))
       }
       condition {
         test     = "ArnLike"
         variable = "aws:PrincipalArn"
         values = distinct(flatten([
           formatlist("arn:aws:iam::%s:role/comms-*-api-event-publisher", var.event_publisher_account_ids),
-          formatlist("arn:aws:iam::%s:role/nhs-notify-*-eventpub", var.event_publisher_account_ids)
+          formatlist("arn:aws:iam::%s:role/nhs-notify-*-eventpub", var.event_publisher_account_ids),
+          (
+            var.template_control_cross_account_source != null
+          ) ? [
+            "arn:aws:iam::${var.template_control_cross_account_source.account_id}:role/nhs-${var.template_control_cross_account_source.environment}-events-template-control-cross-account"
+          ] : []
         ]))
       }
       resources = ["*"]

--- a/infrastructure/terraform/components/events/module_template_control_cross_account_dlq.tf
+++ b/infrastructure/terraform/components/events/module_template_control_cross_account_dlq.tf
@@ -1,0 +1,29 @@
+module "template_control_cross_account_dlq" {
+  count = ( var.template_control_cross_account_target != null ) ? 1 : 0
+  source = "https://github.com/NHSDigital/nhs-notify-shared-modules/releases/download/v2.0.20/terraform-sqs.zip"
+
+  aws_account_id  = var.aws_account_id
+  component       = var.component
+  environment     = var.environment
+  project         = var.project
+  region          = var.region
+  name            = "template-control-cross-account-dlq"
+  sqs_kms_key_arn = module.kms.key_arn
+
+  sqs_policy_overload = data.aws_iam_policy_document.template_control_cross_account_dlq_allow_eventbridge[0].json
+}
+
+data "aws_iam_policy_document" "template_control_cross_account_dlq_allow_eventbridge" {
+  count = ( var.template_control_cross_account_target != null ) ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions   = ["sqs:SendMessage"]
+    resources = [module.template_control_cross_account_dlq[0].sqs_queue_arn]
+  }
+}

--- a/infrastructure/terraform/components/events/variables.tf
+++ b/infrastructure/terraform/components/events/variables.tf
@@ -90,9 +90,27 @@ variable "event_publisher_account_ids" {
 variable "event_target_arns" {
   description = "A map of event target ARNs keyed by name"
   type = object({
-    sms_nudge             = string
-    notify_core_sns_topic = optional(string, null)
+    sms_nudge                               = string
+    notify_core_sns_topic                   = optional(string, null)
   })
+}
+
+variable "template_control_cross_account_target" {
+  description = "Object containing environment and Account ID of the Control Plane Event Bus to send Template Events TO"
+  type = object({
+    environment = optional(string, null)
+    account_id  = optional(string, null)
+  })
+  default = null
+}
+
+variable "template_control_cross_account_source" {
+  description = "Object containing environment and Account ID of the Control Plane Event Bus to allow Template Events FROM"
+  type = object({
+    environment = optional(string, null)
+    account_id  = optional(string, null)
+  })
+  default = null
 }
 
 variable "notify_core_sns_kms_arn" {

--- a/infrastructure/terraform/components/events/versions.tf
+++ b/infrastructure/terraform/components/events/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.10.1"
+  required_version = ">= 1.12.0"
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Allows for cross account delivery of template control events. Though intended for Prod delivery to NonProd, I've kept things generic in terms of naming. 

In practice...

The source environment should define the target in its tfvars and vice versa using the below:

```
variable "template_control_cross_account_target" {
  description = "Object containing environment and Account ID of the Control Plane Event Bus to send Template Events to"
  type = object({
    environment = optional(string, null)
    account_id  = optional(string, null)
  })
  default = null
}

variable "template_control_cross_account_source" {
  description = "Object containing environment and Account ID of the Control Plane Event Bus to allow Template Events FROM"
  type = object({
    environment = optional(string, null)
    account_id  = optional(string, null)
  })
  default = null
}

```
## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
