### PR TITLE
CCM-15633: Subscribe Digital Letters to paperletteroptedout channel statuses

### DIFF
--- a/infrastructure/terraform/components/events/cloudwatch_event_rule_core_to_digital_letters.tf
+++ b/infrastructure/terraform/components/events/cloudwatch_event_rule_core_to_digital_letters.tf
@@ -1,0 +1,59 @@
+resource "aws_cloudwatch_event_rule" "core_to_digital_letters" {
+  name           = "${local.csi}-core-to-digital-letters"
+  description    = "Core events routed to Digital Letters"
+  event_bus_name = aws_cloudwatch_event_bus.data_plane.name
+
+  event_pattern = jsonencode({
+    "detail" : {
+      "type" : [
+        "uk.nhs.notify.channel.status.PUBLISHED.v1",
+      ],
+      "data" : {
+        "supplierStatus" : [
+          "paperletteroptedout"
+        ]
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "core_to_digital_letters" {
+  count = var.event_target_arns["digital_letters_eventbus"] != null ? 1 : 0
+
+  rule           = aws_cloudwatch_event_rule.core_to_digital_letters.name
+  arn            = var.event_target_arns["digital_letters_eventbus"]
+  target_id      = "core-to-digital-letters-eventbus"
+  event_bus_name = aws_cloudwatch_event_bus.data_plane.name
+  role_arn       = aws_iam_role.core_to_digital_letters[0].arn
+}
+
+resource "aws_iam_role" "core_to_digital_letters" {
+  count = var.event_target_arns["digital_letters_eventbus"] != null ? 1 : 0
+
+  name = "${local.csi}-core-to-digital-letters"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "events.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "core_to_digital_letters" {
+  count = var.event_target_arns["digital_letters_eventbus"] != null ? 1 : 0
+
+  role = aws_iam_role.core_to_digital_letters[0].id
+
+  policy = jsonencode({
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "events:PutEvents"
+      Resource = var.event_target_arns["digital_letters_eventbus"]
+    }]
+  })
+}

--- a/infrastructure/terraform/components/events/cloudwatch_event_rule_supplier_api_to_digital_letters.tf
+++ b/infrastructure/terraform/components/events/cloudwatch_event_rule_supplier_api_to_digital_letters.tf
@@ -35,7 +35,7 @@ resource "aws_cloudwatch_event_target" "supplier_api_to_digital_letters" {
 resource "aws_iam_role" "supplier_api_to_digital_letters" {
   count = var.event_target_arns["digital_letters_eventbus"] != null ? 1 : 0
 
-  name = "${local.csi}-supplier-api-to-digital-letter"
+  name = "${local.csi}-supplier-api-to-digital-letters"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR adds a new rule and target to send `uk.nhs.notify.channel.status.PUBLISHED.v1` events with a `data.supplierStatus` value of `paperletteroptedout` to the Digital Letters event bus.

The schema for `uk.nhs.notify.channel.status.PUBLISHED.v1` events is available [here](https://github.com/NHSDigital/comms-mgr/blob/main/packages/status-published-event-schemas/schemas/ChannelStatusPublishedEvent/v1.json).


## Context

To determine whether a digital letter has been read by a patient within the NHS App, a new callback status of paperletteroptedout will be produced by the NHS app and then published by core to the shared event bus. Digital Letters needs to subscribe to these events to know what the read status of the PDF letter is, so that we can decide whether to cascade to a paper letter or not, ensuring that comms still reach patients as trusts expect them to.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. #TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
