### PR TITLE
CCM-15633: Update supplierStatus Rule Match for Digital Letters

### DIFF
--- a/infrastructure/terraform/components/events/cloudwatch_event_rule_core_to_digital_letters.tf
+++ b/infrastructure/terraform/components/events/cloudwatch_event_rule_core_to_digital_letters.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_event_rule" "core_to_digital_letters" {
       ],
       "data" : {
         "supplierStatus" : [
-          "paperletteroptedout"
+          "paper_letter_opted_out"
         ]
       }
     }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR updates the "Core to Digital Letters" rule (added in #123) so that it matches `uk.nhs.notify.channel.status.PUBLISHED.v1` events with a `data.supplierStatus` value of `paper_letter_opted_out`, rather than `paperletteroptedout`.

## Context

This is required because the `paper_letter_opted_out` value aligns better with existing multi-word supplier statuses, so was used in [the Core PR that implemented the new status](https://github.com/NHSDigital/comms-mgr/pull/1337/).

## Validation
See [the Jira ticket](https://nhsd-jira.digital.nhs.uk/browse/CCM-15633) for test evidence.

## Type of changes

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. #TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
